### PR TITLE
Fix action status badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Actions Status](https://github.com/lucs/Test-Selector.git/actions/workflows/test.yml/badge.svg)](https://github.com/lucs/Test-Selector.git/actions)
+[![Actions Status](https://github.com/lucs/Test-Selector/actions/workflows/test.yml/badge.svg)](https://github.com/lucs/Test-Selector/actions)
 
 NAME
 ====


### PR DESCRIPTION
The URLs to the action status badge fail because of the .git after the repo name.